### PR TITLE
Implement player controller and camera rig

### DIFF
--- a/Assets/_Project.meta
+++ b/Assets/_Project.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3f142bb138d8f234dbf83a49c24c719a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts.meta
+++ b/Assets/_Project/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4b2dcb72800a4a3a9d20bce18ffac90a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/Camera.meta
+++ b/Assets/_Project/Scripts/Camera.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8c65c9dd8f91435e9ff9f37fa75d4be9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/Camera/CameraRig.cs
+++ b/Assets/_Project/Scripts/Camera/CameraRig.cs
@@ -1,0 +1,175 @@
+using Cinemachine;
+using UnityEngine;
+using UnityEngine.InputSystem;
+using _Project.Settings;
+
+namespace _Project.Cameras
+{
+    [DisallowMultipleComponent]
+    public class CameraRig : MonoBehaviour
+    {
+        [SerializeField] private CinemachineVirtualCamera virtualCamera;
+        [SerializeField] private Transform followTarget;
+        [SerializeField] private PlayerInput playerInput;
+        [SerializeField] private PlayerSettingsSO playerSettings;
+        [SerializeField] private string lookActionName = "Look";
+        [SerializeField] private Vector2 verticalClamp = new Vector2(-35f, 60f);
+        [SerializeField, Min(0f)] private float horizontalSpeed = 300f;
+        [SerializeField, Min(0f)] private float verticalSpeed = 250f;
+
+        private CinemachinePOV _pov;
+        private InputAction _lookAction;
+
+        private void Awake()
+        {
+            ResolveCameraDependencies();
+            CacheLookAction();
+            ApplyFollowTarget();
+            ApplyAxisSettings();
+        }
+
+        private void OnEnable()
+        {
+            ResolveCameraDependencies();
+            CacheLookAction();
+            ApplyFollowTarget();
+            ApplyAxisSettings();
+        }
+
+        private void OnDisable()
+        {
+            _lookAction = null;
+        }
+
+        private void LateUpdate()
+        {
+            if (_pov == null || _lookAction == null)
+            {
+                return;
+            }
+
+            Vector2 lookValue = _lookAction.ReadValue<Vector2>();
+            float sensitivity = playerSettings != null ? Mathf.Max(0.01f, playerSettings.LookSensitivity) : 1f;
+
+            lookValue *= sensitivity;
+
+            if (playerSettings != null)
+            {
+                if (playerSettings.InvertHorizontal)
+                {
+                    lookValue.x = -lookValue.x;
+                }
+
+                if (playerSettings.InvertVertical)
+                {
+                    lookValue.y = -lookValue.y;
+                }
+            }
+
+            _pov.m_HorizontalAxis.m_InputAxisValue = lookValue.x;
+            _pov.m_VerticalAxis.m_InputAxisValue = lookValue.y;
+        }
+
+        public void SetFollowTarget(Transform target)
+        {
+            followTarget = target;
+            ApplyFollowTarget();
+        }
+
+        public void SetPlayerInput(PlayerInput input)
+        {
+            playerInput = input;
+            CacheLookAction();
+        }
+
+        public void SetPlayerSettings(PlayerSettingsSO settings)
+        {
+            playerSettings = settings;
+        }
+
+        private void ResolveCameraDependencies()
+        {
+            if (virtualCamera == null)
+            {
+                virtualCamera = GetComponentInChildren<CinemachineVirtualCamera>();
+            }
+
+            if (virtualCamera != null)
+            {
+                _pov = virtualCamera.GetCinemachineComponent<CinemachinePOV>();
+            }
+        }
+
+        private void CacheLookAction()
+        {
+            PlayerInput input = playerInput != null ? playerInput : GetComponentInParent<PlayerInput>();
+            playerInput = input;
+
+            if (input == null || input.actions == null || string.IsNullOrEmpty(lookActionName))
+            {
+                _lookAction = null;
+                return;
+            }
+
+            _lookAction = input.actions.FindAction(lookActionName);
+
+            if (_lookAction != null && !_lookAction.enabled)
+            {
+                _lookAction.Enable();
+            }
+        }
+
+        private void ApplyFollowTarget()
+        {
+            if (virtualCamera == null)
+            {
+                return;
+            }
+
+            if (followTarget == null && playerInput != null)
+            {
+                followTarget = playerInput.transform;
+            }
+
+            if (followTarget == null)
+            {
+                followTarget = transform;
+            }
+
+            virtualCamera.Follow = followTarget;
+            if (virtualCamera.LookAt == null)
+            {
+                virtualCamera.LookAt = followTarget;
+            }
+        }
+
+        private void ApplyAxisSettings()
+        {
+            if (_pov == null)
+            {
+                return;
+            }
+
+            _pov.m_VerticalAxis.m_MinValue = verticalClamp.x;
+            _pov.m_VerticalAxis.m_MaxValue = verticalClamp.y;
+            _pov.m_VerticalAxis.m_Wrap = false;
+            _pov.m_HorizontalAxis.m_Wrap = true;
+            _pov.m_HorizontalAxis.m_MaxSpeed = horizontalSpeed;
+            _pov.m_VerticalAxis.m_MaxSpeed = verticalSpeed;
+        }
+
+        private void OnValidate()
+        {
+            if (verticalClamp.y < verticalClamp.x)
+            {
+                verticalClamp.y = verticalClamp.x;
+            }
+
+            if (!Application.isPlaying)
+            {
+                ResolveCameraDependencies();
+                ApplyAxisSettings();
+            }
+        }
+    }
+}

--- a/Assets/_Project/Scripts/Camera/CameraRig.cs.meta
+++ b/Assets/_Project/Scripts/Camera/CameraRig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5be1ae5470804ccaae32f9e8e08568ad
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/Gameplay.meta
+++ b/Assets/_Project/Scripts/Gameplay.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 72b6e77e5f654d8eb4ff6c09ebf1423f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/Gameplay/Player.meta
+++ b/Assets/_Project/Scripts/Gameplay/Player.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3d4b1ce9c87c4e8ea932c1e16909f65b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/Gameplay/Player/PlayerController.cs
+++ b/Assets/_Project/Scripts/Gameplay/Player/PlayerController.cs
@@ -1,0 +1,211 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+namespace _Project.Gameplay.Player
+{
+    [RequireComponent(typeof(Rigidbody))]
+    [RequireComponent(typeof(PlayerInput))]
+    public class PlayerController : MonoBehaviour
+    {
+        private const float SprintButtonThreshold = 0.5f;
+
+        [Header("Movement")]
+        [SerializeField, Min(0f)] private float walkSpeed = 6f;
+        [SerializeField, Min(0f)] private float sprintSpeed = 10f;
+        [SerializeField, Min(0f)] private float acceleration = 20f;
+        [SerializeField, Range(0f, 1f)] private float airControlMultiplier = 0.5f;
+
+        [Header("Jump")]
+        [SerializeField, Min(0f)] private float jumpHeight = 3f;
+        [SerializeField, Min(0f)] private float jumpBufferTime = 0.1f;
+        [SerializeField, Min(0f)] private float coyoteTime = 0.1f;
+        [SerializeField, Min(0f)] private float gravityMultiplier = 1.5f;
+
+        [Header("Ground Check")]
+        [SerializeField] private LayerMask groundMask = ~0;
+        [SerializeField] private Vector3 groundCheckOffset = new Vector3(0f, -0.9f, 0f);
+        [SerializeField, Range(0.05f, 1f)] private float groundCheckRadius = 0.25f;
+        [SerializeField] private bool drawGroundCheckGizmo = true;
+
+        private Rigidbody _rigidbody;
+        private PlayerInput _playerInput;
+        private InputAction _moveAction;
+        private InputAction _jumpAction;
+        private InputAction _sprintAction;
+
+        private Vector2 _moveInput;
+        private bool _isSprinting;
+        private bool _isGrounded;
+        private float _lastTimeGrounded;
+        private float _lastJumpPressedTime = float.NegativeInfinity;
+
+        private void Awake()
+        {
+            _rigidbody = GetComponent<Rigidbody>();
+            _rigidbody.useGravity = false;
+            _rigidbody.constraints = RigidbodyConstraints.FreezeRotation;
+
+            _playerInput = GetComponent<PlayerInput>();
+        }
+
+        private void OnEnable()
+        {
+            CacheActions();
+        }
+
+        private void OnDisable()
+        {
+            ReleaseActions();
+        }
+
+        private void Update()
+        {
+            PollInput();
+        }
+
+        private void FixedUpdate()
+        {
+            UpdateGroundedState();
+            HandleMovement();
+            HandleJump();
+            ApplyCustomGravity();
+        }
+
+        private void CacheActions()
+        {
+            if (_playerInput == null)
+            {
+                return;
+            }
+
+            _moveAction = _playerInput.actions?.FindAction("Move");
+            _jumpAction = _playerInput.actions?.FindAction("Jump");
+            _sprintAction = _playerInput.actions?.FindAction("Sprint");
+        }
+
+        private void ReleaseActions()
+        {
+            _moveAction = null;
+            _jumpAction = null;
+            _sprintAction = null;
+        }
+
+        private void PollInput()
+        {
+            if (_moveAction != null)
+            {
+                _moveInput = _moveAction.ReadValue<Vector2>();
+            }
+
+            if (_sprintAction != null)
+            {
+                _isSprinting = _sprintAction.ReadValue<float>() > SprintButtonThreshold;
+            }
+
+            if (_jumpAction != null && _jumpAction.WasPerformedThisFrame())
+            {
+                _lastJumpPressedTime = Time.time;
+            }
+
+            if (_jumpAction != null && _jumpAction.WasReleasedThisFrame())
+            {
+                Vector3 velocity = _rigidbody.velocity;
+                if (velocity.y > 0f)
+                {
+                    velocity.y *= 0.5f;
+                    _rigidbody.velocity = velocity;
+                }
+            }
+        }
+
+        private void UpdateGroundedState()
+        {
+            Vector3 checkPosition = transform.TransformPoint(groundCheckOffset);
+            _isGrounded = Physics.CheckSphere(checkPosition, groundCheckRadius, groundMask, QueryTriggerInteraction.Ignore);
+
+            if (_isGrounded)
+            {
+                _lastTimeGrounded = Time.time;
+            }
+        }
+
+        private void HandleMovement()
+        {
+            Vector3 input = new Vector3(_moveInput.x, 0f, _moveInput.y);
+            input = Vector3.ClampMagnitude(input, 1f);
+
+            Vector3 moveDirection = transform.TransformDirection(input);
+            moveDirection.y = 0f;
+            moveDirection.Normalize();
+
+            float targetSpeed = _isSprinting ? sprintSpeed : walkSpeed;
+            Vector3 targetVelocity = moveDirection * targetSpeed;
+
+            Vector3 currentVelocity = _rigidbody.velocity;
+            Vector3 planarVelocity = new Vector3(currentVelocity.x, 0f, currentVelocity.z);
+
+            float control = _isGrounded ? 1f : airControlMultiplier;
+            float maxSpeedChange = acceleration * control * Time.fixedDeltaTime;
+            planarVelocity = Vector3.MoveTowards(planarVelocity, targetVelocity, maxSpeedChange);
+
+            _rigidbody.velocity = new Vector3(planarVelocity.x, currentVelocity.y, planarVelocity.z);
+        }
+
+        private void HandleJump()
+        {
+            bool jumpBuffered = Time.time - _lastJumpPressedTime <= jumpBufferTime;
+            bool coyoteAllowed = Time.time - _lastTimeGrounded <= coyoteTime;
+
+            if (!jumpBuffered || !coyoteAllowed)
+            {
+                return;
+            }
+
+            float gravity = Mathf.Abs(Physics.gravity.y) * gravityMultiplier;
+            if (gravity <= 0f)
+            {
+                gravity = 9.81f * gravityMultiplier;
+            }
+            gravity = Mathf.Max(gravity, 0.01f);
+
+            float jumpVelocity = Mathf.Sqrt(2f * gravity * jumpHeight);
+
+            Vector3 velocity = _rigidbody.velocity;
+            velocity.y = jumpVelocity;
+            _rigidbody.velocity = velocity;
+
+            _lastJumpPressedTime = float.NegativeInfinity;
+            _isGrounded = false;
+        }
+
+        private void ApplyCustomGravity()
+        {
+            Vector3 velocity = _rigidbody.velocity;
+            float gravity = Mathf.Abs(Physics.gravity.y) * gravityMultiplier;
+            gravity = Mathf.Max(gravity, 0.01f);
+
+            if (_isGrounded && velocity.y < 0f)
+            {
+                velocity.y = -2f;
+            }
+            else
+            {
+                velocity.y -= gravity * Time.fixedDeltaTime;
+            }
+
+            _rigidbody.velocity = velocity;
+        }
+
+        private void OnDrawGizmosSelected()
+        {
+            if (!drawGroundCheckGizmo)
+            {
+                return;
+            }
+
+            Gizmos.color = Color.green;
+            Vector3 checkPosition = transform.TransformPoint(groundCheckOffset);
+            Gizmos.DrawWireSphere(checkPosition, groundCheckRadius);
+        }
+    }
+}

--- a/Assets/_Project/Scripts/Gameplay/Player/PlayerController.cs.meta
+++ b/Assets/_Project/Scripts/Gameplay/Player/PlayerController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6dfe5c38e1f64f6f8564374b65e1a0f5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Settings.meta
+++ b/Assets/_Project/Settings.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bc0a31df6300426d887f53d2dfc4efa2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Settings/PlayerSettings.asset
+++ b/Assets/_Project/Settings/PlayerSettings.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fcd92ff2d3254f6a8d57f32bce49963f, type: 3}
+  m_Name: PlayerSettings
+  m_EditorClassIdentifier: 
+  lookSensitivity: 1
+  invertHorizontal: 0
+  invertVertical: 0

--- a/Assets/_Project/Settings/PlayerSettings.asset.meta
+++ b/Assets/_Project/Settings/PlayerSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 459c6e46fc7b4bb7bb6a2c4c7fa6a28d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Settings/PlayerSettingsSO.cs
+++ b/Assets/_Project/Settings/PlayerSettingsSO.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace _Project.Settings
+{
+    [CreateAssetMenu(menuName = "_Project/Settings/Player Settings", fileName = "PlayerSettings")]
+    public class PlayerSettingsSO : ScriptableObject
+    {
+        [SerializeField, Range(0.01f, 10f)] private float lookSensitivity = 1f;
+        [SerializeField] private bool invertHorizontal;
+        [SerializeField] private bool invertVertical;
+
+        public float LookSensitivity => lookSensitivity;
+        public bool InvertHorizontal => invertHorizontal;
+        public bool InvertVertical => invertVertical;
+    }
+}

--- a/Assets/_Project/Settings/PlayerSettingsSO.cs.meta
+++ b/Assets/_Project/Settings/PlayerSettingsSO.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fcd92ff2d3254f6a8d57f32bce49963f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add a Rigidbody-based player controller with WASD movement, sprinting, jumping and coyote/buffer timings
- implement a Cinemachine camera rig that reads sensitivity and inversion values from the shared player settings asset
- add a PlayerSettings ScriptableObject asset to store default look preferences

## Testing
- not run (Unity editor required)


------
https://chatgpt.com/codex/tasks/task_e_68ce8dbface4832ebcf86b78cc0defbb